### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,10 @@ app {
 }
 
 dependencies {
-    include 'com.enonic.lib:lib-mustache:2.1.1'
-    include 'com.enonic.lib:lib-http-client:4.0.0-SNAPSHOT'
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
+    include libs.lib.mustache
+    include libs.lib.http.client
+    include libs.lib.static
+    include libs.lib.router
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+http-client = "4.0.0-SNAPSHOT"
+mustache = "2.1.1"
+router = "4.0.0-SNAPSHOT"
+static = "3.0.0-SNAPSHOT"
+
+[libraries]
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }


### PR DESCRIPTION
## Summary

Migrate the four inline `com.enonic.lib:*` versions in `build.gradle` into a new `gradle/libs.versions.toml` catalog, pin-for-pin. No version bumps, no other build changes.

Conventions adopted (matching `app-simple-idprovider` / the task spec):

- Version keys: short, lowercase, hyphen-separated (`http-client`, not `httpClient`).
- Library keys: kebab-case with `lib-` prefix (`lib-http-client`).
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` left in `gradle.properties` — not part of the catalog.

## Catalog content

```toml
[versions]
http-client = "4.0.0-SNAPSHOT"
mustache = "2.1.1"
router = "4.0.0-SNAPSHOT"
static = "3.0.0-SNAPSHOT"

[libraries]
lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
```

## Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` output is byte-identical before vs. after.

## Test plan

- [x] Build passes with `--refresh-dependencies`.
- [x] Resolved runtime classpath unchanged.